### PR TITLE
The modal is hidden in CSS and Vite handles the style order

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
         "openingHours": "Mo-Su 09:00-22:00"
       }
     </script>
+    <link rel="stylesheet" href="./src/styles/layouts/main.scss">
     <script type="module" src="./src/js/main.js"></script>
     <!-- <script type="module" src="./src/js/menu.js"></script> -->
     <script type="module" src="./src/js/menu.js"></script>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,3 @@
-import '../styles/layouts/main.scss';
-import '../styles/layouts/modal.scss';
-import '../styles/layouts/header.scss';
+// import '../styles/layouts/main.scss';
+// import '../styles/layouts/modal.scss';
+// import '../styles/layouts/header.scss';

--- a/src/js/modal1.js
+++ b/src/js/modal1.js
@@ -85,10 +85,10 @@ export const openBookingModal = (id) => {
 
 // Hide the modal on page load
 document.addEventListener("DOMContentLoaded", () => {
-  modal.style.display = "none";
-  console.log("Modal is hidden when the page is loaded");
+  // modal.style.display = "none";
 
   setMinimumSelectableDate();
+  console.log("Just minimum selectable date");
 });
 
 closeBTN.forEach(button =>{

--- a/src/styles/layouts/main.scss
+++ b/src/styles/layouts/main.scss
@@ -2,6 +2,8 @@
 @use '../global-styles/_fonts.scss' as *;
 @use '../global-styles/_screens.scss' as *;
 @use '../global-styles/_colors.scss' as *;
+@use '../layouts/modal.scss' as *;
+@use '../layouts/header.scss' as *;
 @use 'header.scss';
 @use 'testimonials.scss';
 @use 'story.scss';

--- a/src/styles/layouts/modal.scss
+++ b/src/styles/layouts/modal.scss
@@ -3,6 +3,10 @@
 @use '../global-styles/_screens.scss' as *;
 @use '../global-styles/_colors.scss' as *;
 
+.booking-modal {
+    display: none;
+}
+
 .booking-modal__step{ 
     display: block;//Initially hidden, pops up with btn
     position: fixed; //modal is in its fixed position when scrolling


### PR DESCRIPTION
#Case 1
Vite handles the loading of CSS and the page is loading as usual now.
![image](https://github.com/user-attachments/assets/ff04cc55-9ddd-4a90-bc5a-f9b706d5ee98)
![image](https://github.com/user-attachments/assets/74068425-0847-4eaa-9ef4-fe97bff59615)
![image](https://github.com/user-attachments/assets/42e0df7c-4733-463b-a51d-bc3285336452)


#Case 2
Because the modal is created in the index HTML, it becomes complicated to hide it before the HTML is loaded.
It's easiest to do it directly in CSS.
![image](https://github.com/user-attachments/assets/a5e0d2aa-ad96-4a12-9956-49c6f5e8a40c)
![image](https://github.com/user-attachments/assets/187f8e52-3c8d-4338-a0ab-ae2861ba5614)
