### PR TITLE
fix: empty stars shows only if rating is 0

### DIFF
--- a/src/js/challengeClass.js
+++ b/src/js/challengeClass.js
@@ -43,7 +43,7 @@ class Challenge {
       } else if (i === Math.ceil(rate) && rate % 1 !== 0) {
         star.src = starHalf; 
         star.className = "star half";
-      } else {
+      } else if (rate === 0){
         star.src = starEmpty;
         star.className = "star unfilled";
       }

--- a/src/js/challengeClass.js
+++ b/src/js/challengeClass.js
@@ -46,6 +46,8 @@ class Challenge {
       } else if (rate === 0){
         star.src = starEmpty;
         star.className = "star unfilled";
+        challengeRating.appendChild(star);
+        return challengeRating;
       }
 
       challengeRating.appendChild(star);


### PR DESCRIPTION
A simple solution:

- Removes all stars after the half-star
- Adding empty stars only if the rating is below zero

I think it looks better now
If someone have more ideas I'm open.