### PR TITLE
feat: delay search until at least three characters have been entered

### DIFF
--- a/src/js/filteringBox.js
+++ b/src/js/filteringBox.js
@@ -362,14 +362,17 @@ function getUniqueTags(filteredResults) {
 
 // Delayed search from input event
 function debounceSearch(event) {
-    clearTimeout(searchDebounceTimer);
-    searchDebounceTimer = setTimeout(() => 
-        executeSearch(event.target.value), searchDebounceDelay);
 
+    clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+        searchField = event.target;
+        executeSearch(event.target.value)}, searchDebounceDelay);
+    
 }
 
 //Perform search on challenges array from case-insensitive userinput 
 function executeSearch(query) {
+
     const challengesArray = getChallengesArray();
     console.log("All challenges:", challengesArray); 
     const onlineChecked = document.getElementById("DOM__checkBox1").checked;
@@ -378,6 +381,7 @@ function executeSearch(query) {
         const matchesRating = challenge.rating >= ratingStars["lowestRating"] && challenge.rating <= ratingStars["highestRating"];
         
         const matchesQuery =
+            query.length < 3 ||
             challenge.title.toLowerCase().includes(query.toLowerCase()) || 
             challenge.description.toLowerCase().includes(query.toLowerCase()) ||
             challenge.labels.some(label =>


### PR DESCRIPTION
This PR adds delayed search to search input on filteringbox.

These are the included changes:

1. Addition of delayed search until query in search field reaches 3 characters

Changes made:
- Modified the function executeSearch
- Modified the function debounceSearch

Testing:
- Verified that challenges render correctly in the DOM when input are: 0, 1, 2, or 3 characters
- Confirmed that the search input are properly associated with their respective challenges

Next steps:
- None

Please review the changes and provide any feedback on the structure or naming conventions used.