### PR TITLE
Add a breakpoint for very wide screens and display 4 challenges per row.

### DIFF
--- a/src/styles/global-styles/_screens.scss
+++ b/src/styles/global-styles/_screens.scss
@@ -5,7 +5,12 @@
   }
 
 @mixin large-screen {
-    @media screen and (min-width: 869px)and (max-width:1599px) { //640 px
+    @media screen and (min-width: 869px) { //640 px
+        @content;
+    }
+}
+@mixin large-screen-special {
+    @media screen and (min-width: 869px) and (max-width:1599px) { //640 px
         @content;
     }
 }

--- a/src/styles/global-styles/_screens.scss
+++ b/src/styles/global-styles/_screens.scss
@@ -5,7 +5,7 @@
   }
 
 @mixin large-screen {
-    @media screen and (min-width: 869px) { //640 px
+    @media screen and (min-width: 869px)and (max-width:1599px) { //640 px
         @content;
     }
 }

--- a/src/styles/global-styles/_screens.scss
+++ b/src/styles/global-styles/_screens.scss
@@ -10,8 +10,8 @@
     }
 }
 
-// @mixin large-screen {
-//     @media screen and (min-width: 1367px) {
-//         @content;
-//     }
-// }
+@mixin x-large-screen {
+    @media screen and (min-width: 1600px) {
+        @content;
+    }
+}

--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -135,7 +135,7 @@
   }
 }
 
-@include large-screen {
+@include large-screen-special {
   .challenges {
     position: static;
     width: 100vw;

--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -154,7 +154,7 @@
     }
     .challenges__list{
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
       gap: 20px;
 }
   }
@@ -196,3 +196,11 @@
 }
 
 // }
+@include x-large-screen{
+  .challenges__list{
+    display: grid;
+    grid-template-columns: repeat(4, 1fr); 
+    gap: 20px;
+    width: 100%;
+  }
+}

--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -199,8 +199,13 @@
 @include x-large-screen{
   .challenges__list{
     display: grid;
-    grid-template-columns: repeat(4, 1fr); 
+    grid-template-columns: repeat(4, auto);
     gap: 20px;
     width: 100%;
+    margin: auto;
+  }
+  .challengey {
+    width: 100%; 
+    margin: 0;
   }
 }


### PR DESCRIPTION
This PR introduces a new breakpoint for screens wider than 1600px and updates the layout to display 4 challenges per row at this width. Additionally:

Ensures balanced margins and paddings for all screen sizes.
Refactors SCSS code to follow DRY principles and improve readability.

**Changes**
1- Breakpoint: Added a media query for min-width: 1600px in _screens.scss.
2- Grid Layout: Updated .rooms layout to use grid-template-columns: repeat(4, 1fr) for very wide screens.
Ensured proper alignment and spacing between elements.
3- Responsive Design: Verified layout remains functional on smaller screens (large and small breakpoints).
Improved margins and paddings for consistency.

**Testing** 
Tested and Verified that  4 challenges per row on screens wider than 1600px and checked responsiveness and layout balance for smaller screens.
1- Desktop up to 2000px.
2- Mobile (375px, 768px).
3- Google Chrome.
4- Mozilla Firefox.
Scenarios:

solves; issue# 100
