### PR TITLE
Added more responsiveness to title (rooms.scss)

### DIFF
--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -209,25 +209,3 @@
     margin: 0;
   }
 }
-
-/*For screens smaller than 1000px*/
-@media (max-width: 1000px) {
-  .challenges__title {
-    font-size: 1.5rem; 
-    padding: 0 10px;  
-    position: relative; 
-    top: auto;         
-    text-align: center; 
-  }
-}
-
-/*For screens smaller than 1800px*/
-@media (max-width: 1800px) {
-  .challenges__title {
-    font-size: 2.5rem; 
-    padding: 0 10px;  
-    position: relative; 
-    top: auto;         
-    text-align: center; 
-  }
-}

--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -209,3 +209,25 @@
     margin: 0;
   }
 }
+
+/*For screens smaller than 1000px*/
+@media (max-width: 1000px) {
+  .challenges__title {
+    font-size: 1.5rem; 
+    padding: 0 10px;  
+    position: relative; 
+    top: auto;         
+    text-align: center; 
+  }
+}
+
+/*For screens smaller than 1800px*/
+@media (max-width: 1800px) {
+  .challenges__title {
+    font-size: 2.5rem; 
+    padding: 0 10px;  
+    position: relative; 
+    top: auto;         
+    text-align: center; 
+  }
+}

--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -13,9 +13,6 @@
     text-align: center;
     justify-content: center;
     margin: auto;
-    position: absolute;
-    top: 0;
-    right: 0;
     width: 100%;
     font-size: 1.9rem;
     font-weight: 400;

--- a/src/styles/layouts/rooms.scss
+++ b/src/styles/layouts/rooms.scss
@@ -9,7 +9,7 @@
   max-width: 2000px;
   margin: 15px; // height: 446px;
   
-  &__title {
+  &__title { //This is where I added the changes
     text-align: center;
     justify-content: center;
     margin: auto;


### PR DESCRIPTION
I could not really figure out how to do this in a way that`s similar to Elenas, but the challenges title is better now. It is especially not visible in the header like before. I made it more responsive to different screen varieties. 
I chose a bug label because our page did not look the way it should according to figmas specification. 

This is what I wanted to fix :-)
![Skärmbild 2024-12-10 005216](https://github.com/user-attachments/assets/41df4235-b007-4021-9210-56b0b88f554c)
![Skärmbild 2024-12-10 000055](https://github.com/user-attachments/assets/924e3f5f-b6a3-4425-a943-d4b649df8f3e)


