### PR TITLE
Hide second testimonial in mobile view

### DIFF
--- a/src/styles/layouts/testimonials.scss
+++ b/src/styles/layouts/testimonials.scss
@@ -78,6 +78,9 @@
       font-size: 1.125rem;
     }
   }
+  #testimonial__carousel__slide2{
+    display: none;
+  }
 }
 
 // ----------------------Large Screen Adjustments-----------------------
@@ -85,6 +88,10 @@
   .testimonials {
     width: 100%;
     max-width: 2000px;
+
+    #testimonial__carousel__slide2{
+      display: block;
+    }
 
     &__list {
       max-width: 2000px;

--- a/src/styles/layouts/testimonials.scss
+++ b/src/styles/layouts/testimonials.scss
@@ -11,7 +11,7 @@
   max-width: 2000px;
   margin-bottom: 4rem;
   margin-top: 1.5rem;
-  margin-left: 2rem;
+  margin-left: 1rem;
 
   &__container {
     width: 95vw;


### PR DESCRIPTION
This PR addresses the issue where multiple testimonials were being displayed on mobile view, leading to a cluttered and inconsistent layout. The implemented solution hides additional testimonials, ensuring only the first testimonial is displayed in the mobile view for better readability and user experience.

Changes:
1- Updated the CSS to conditionally hide the second testimonial in mobile view and display it in desktop view.
2- Ensured the first testimonial remains visible, while the second is hidden using media queries and responsive design principles.

Testing:  Tested for responsiveness across various screen sizes to confirm the intended behavior.

screen shots:
Before:
![image](https://github.com/user-attachments/assets/2566d9b6-09ba-4477-b4fd-71db1101307c)

After: 
![image](https://github.com/user-attachments/assets/f6e1abe6-2101-43aa-80dc-50b418724e91)
